### PR TITLE
Get rid of some deprecation warnings

### DIFF
--- a/06_past.md
+++ b/06_past.md
@@ -81,7 +81,7 @@ Earlier we said that there is a built-in clock domain, `sync`. However, you stil
 Assumptions force the verification engine to ensure that the assumptions are true. So for example, suppose `x` were an input to some module that you want to verify:
 
 ```python
-from amaranth.asserts import Assume
+from amaranth.hdl import Assume
 
 x = Signal(16)  # An input signal
 m.d.comb += Assume(x < 0xD000)

--- a/answers/e01_to_pennies.py
+++ b/answers/e01_to_pennies.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/answers/e02_next_day.py
+++ b/answers/e02_next_day.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/answers/e03_cell3x3.py
+++ b/answers/e03_cell3x3.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/answers/e03_cell4x4.py
+++ b/answers/e03_cell4x4.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from e03_cell3x3 import Cell3x3
 from util import main

--- a/answers/e04_negate.py
+++ b/answers/e04_negate.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 from amaranth.lib.coding import PriorityEncoder
 
 from util import main

--- a/answers/e04_signed_compare.py
+++ b/answers/e04_signed_compare.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 from amaranth.lib.coding import PriorityEncoder
 
 from util import main

--- a/answers/e05_counter.py
+++ b/answers/e05_counter.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/answers/e06_counter.py
+++ b/answers/e06_counter.py
@@ -4,7 +4,8 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable, ClockSignal, ResetSignal, ClockDomain
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover, Past, Initial, Rose
+from amaranth.asserts import Past, Initial, Rose
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/answers/e07_counter.py
+++ b/answers/e07_counter.py
@@ -4,7 +4,8 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable, ClockSignal, ResetSignal, ClockDomain
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover, Past, Initial, Rose
+from amaranth.asserts import Past, Initial, Rose
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/skeleton.py
+++ b/skeleton.py
@@ -4,7 +4,7 @@ from typing import List, Tuple
 
 from amaranth import Signal, Module, Elaboratable
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 
 from util import main
 

--- a/skeleton_sync.py
+++ b/skeleton_sync.py
@@ -5,7 +5,7 @@ from typing import List, Tuple
 from amaranth import Signal, Module, Elaboratable
 from amaranth import ClockSignal, ResetSignal
 from amaranth.build import Platform
-from amaranth.asserts import Assume, Assert, Cover
+from amaranth.hdl import Assume, Assert, Cover
 from amaranth.asserts import Past, Initial
 
 from util import main


### PR DESCRIPTION
It's been deprecated since Amaranth commit bfe541a6d7f63b7a8402d86aa51e741c7d1c97bd (2024-03-06)
See PR: https://github.com/amaranth-lang/amaranth/pull/1190
Deprecated since Amaranth release v0.5.0